### PR TITLE
Ajout npm dans le package.list

### DIFF
--- a/package.list
+++ b/package.list
@@ -7,6 +7,7 @@ gvfs-nfs
 gvfs-smb
 mariadb
 mariadb-clients
+npm
 obs-studio
 php
 easystroke


### PR DESCRIPTION
Pour éviter que rails s plante au premier démarrage car la gem uglifier a besoin de npm