### PR TITLE
Fix keymap previous workspace

### DIFF
--- a/config/i3/.config/i3/config
+++ b/config/i3/.config/i3/config
@@ -182,7 +182,7 @@ bindsym $mod+underscore workspace $ws8
 bindsym $mod+ccedilla workspace $ws9
 bindsym $mod+agrave workspace $ws10
 bindsym $mod+Tab workspace next
-bindsym $mode+Shift+Tab workspace prev
+bindsym $mod+Shift+Tab workspace prev
 bindsym $mod+Ctrl+Right workspace next
 bindsym $mod+Ctrl+Left workspace prev
 bindsym $mod+Ctrl+j workspace next


### PR DESCRIPTION
Il y avait un "e" en trop qui rendait impossible d'aller au workspace precedant avec Mod + Shift + Tab